### PR TITLE
Peer Deps for ng14 and ng15

### DIFF
--- a/angular/heroicons/package-lock.json
+++ b/angular/heroicons/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "ng-heroicon",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ng-heroicon",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "^13.2.1",
-        "@angular/core": "^13.2.1"
+        "@angular/common": "13.x - 15.x",
+        "@angular/core": "13.x - 15.x"
       }
     },
     "node_modules/@angular/common": {

--- a/angular/heroicons/package.json
+++ b/angular/heroicons/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/renatoaraujoc/heroicons.git"
   },
   "peerDependencies": {
-    "@angular/common": "^13.2.1",
-    "@angular/core": "^13.2.1"
+    "@angular/common": "13.x - 15.x",
+    "@angular/core": "13.x - 15.x"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
Hey there

Would be awesome if we could bump the peer deps a bit in order to avoid npms --legacy-peer-deps flag when using angular 14 (or 15). 